### PR TITLE
Make manpage compatible with mandoc

### DIFF
--- a/tdl.1
+++ b/tdl.1
@@ -851,8 +851,8 @@ l l.
 +1d\-08 & 8am tomorrow
 +1w\-08 & 8am on the same day as today next week
 +6h\-08 & 8am on the day containing the time 6 hours ahead of now
-\.\-08 & 8am today
-\.\-20 & 8pm today
+\&\.\-08 & 8am today
+\&\.\-20 & 8pm today
 20011020 & absolute : 12 noon on 20th October 2001
 011020 & absolute : 12 noon on 20th October 2001 (current century)
 1020 & absolute : 12 noon on 20th October 2001 (current century and year)


### PR DESCRIPTION
& is a dummy character that is not rendered.

Without it mandoc thinks .- is a macro which it does not support.

mandoc is the default manpage renderer on BSD systems.

Without this change on a fresh FreeBSD:

```
# man work/tdl-1.6pre2/tdl.1
This manpage needs groff(1) to be rendered
First install groff(1): 
pkg install groff
```

With this change the manpage renders perfectly. Rendering with groff is identical with and without.